### PR TITLE
Corrección sobre el método insert de ProductService

### DIFF
--- a/src/main/java/com/unla/grupo7/services/implementation/ProductService.java
+++ b/src/main/java/com/unla/grupo7/services/implementation/ProductService.java
@@ -110,7 +110,7 @@ public class ProductService implements IProductService
 	@Override
 	public Product insert(Product product) throws Exception
 	{
-		if(findByCode(product.getCode()) != null) 
+		if(productRepository.findByCode(product.getCode()) != null) 
 		{
 			throw new Exception("ERROR the product is existent");
 		}


### PR DESCRIPTION
En este commit, realizo una corrección sobre la implementación del método insert de ProductService para que pueda verificar correctamente si existe otro producto en la base de datos con el mismo código con el objetivo de lanzar una excepción en caso de que esto ocurra y evitar la duplicidad de códigos en la base de datos.