### PR TITLE
Eliminamos librerías importadas innecesariamente

### DIFF
--- a/src/main/java/com/unla/grupo7/controllers/UserController.java
+++ b/src/main/java/com/unla/grupo7/controllers/UserController.java
@@ -1,10 +1,8 @@
 package com.unla.grupo7.controllers;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import com.unla.grupo7.entities.User;
 import com.unla.grupo7.helpers.ViewRouteHelper;
 
 
@@ -31,8 +29,6 @@ public class UserController {
 	
 	@GetMapping("/loginsuccess")
 	public String loginCheck() {
-		//User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-		//user.getUserRoles()
 		return "redirect:/index";
 	}
 }

--- a/src/main/java/com/unla/grupo7/entities/Product.java
+++ b/src/main/java/com/unla/grupo7/entities/Product.java
@@ -1,13 +1,9 @@
 package com.unla.grupo7.entities;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/unla/grupo7/entities/SupplyOrder.java
+++ b/src/main/java/com/unla/grupo7/entities/SupplyOrder.java
@@ -1,7 +1,5 @@
 package com.unla.grupo7.entities;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/unla/grupo7/services/IPurchaseService.java
+++ b/src/main/java/com/unla/grupo7/services/IPurchaseService.java
@@ -2,7 +2,6 @@ package com.unla.grupo7.services;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import com.unla.grupo7.entities.Purchase;
 

--- a/src/main/java/com/unla/grupo7/services/ISupplyOrderService.java
+++ b/src/main/java/com/unla/grupo7/services/ISupplyOrderService.java
@@ -1,7 +1,6 @@
 package com.unla.grupo7.services;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.unla.grupo7.entities.SupplyOrder;
 


### PR DESCRIPTION
Limpiamos el código removiendo las librerías que habíamos importados en determinados archivos pero que finalmente quedaron sin emplearse para el desarrollo del código.